### PR TITLE
Added following tasks to the install_and_configure.yml

### DIFF
--- a/install_and_configure.yml
+++ b/install_and_configure.yml
@@ -3,6 +3,23 @@
   gather_facts: false
 
   tasks:
+    - name: Download apt key
+      get_url:
+        url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        dest: /tmp # or /etc/pki/rpm-gpg depending on the infrastructure
+
+    - name: Add a key from a file
+      ansible.builtin.apt_key:
+        file: /tmp/apt-key.gpg
+        state: present
+
+    - name: Set up cuda key
+      tags: experiment
+      shell: |
+        sudo apt-key del 7fa2af80
+        sudo wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
+        sudo -i cuda-keyring_1.0-1_all.deb
+
     - name: Update the apt package index
       tags: experiment
       become: yes
@@ -48,7 +65,7 @@
       shell: |
         sh -c echo -1 >/proc/sys/kernel/perf_event_paranoid
         sysctl -w kernel.perf_event_paranoid=-1
-      
+
     - name: add apt signing key from official docker repo
       tags: experiment
       become: true
@@ -105,7 +122,27 @@
       become: true
       become_user: "{{ user }}"
       shell: |
-        git clone https://github.com/NVIDIA/nvidia-docker.git
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+        distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+              && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+              && curl -s -L https://nvidia.github.io/libnvidia-container/experimental/$distribution/libnvidia-container.list | \
+                 sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+                 sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        cd nvidia-docker
+        make
+
+    - name: clone and install nvidia-smi 470
+      tags: experiment
+      when: not nvidiadocker.stat.exists
+      become: true
+      become_user: "{{ user }}"
+      shell: |
+        apt-get purge nvidia-*
+        apt-get update
+        apt-get autoremove
+        apt install libnvidia-common-470
+        apt install libnvidia-gl-470
+        apt install nvidia-driver-470
         cd nvidia-docker
         make
 


### PR DESCRIPTION
Download apt key: It gets the new apt key as running the script at first gives the error of outdated keys

Set up cuda key: It removes the outdated key and gets the new ones Link for the complete solution:  https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

Nvidia installation gives LIB_Version must be specified error

Clone and install nvidia-docker: Changed the shell section to get the latest version of nvidia according to the git repository

Clone and install nvidia-smi 470: It removes all the nvidia drivers which may be incompatible with the models and cause error and instead it installs the 470 version which works fine with the models